### PR TITLE
GET requests crashes after previous POST request

### DIFF
--- a/BitfinexAPI.cpp
+++ b/BitfinexAPI.cpp
@@ -1007,12 +1007,12 @@ DoGETrequest(const string &UrlEndPoint, const string &params, string &result)
     if(curl) {
         
         string url = APIurl + UrlEndPoint + params;
-		
-		curl = curl_easy_init();
+        
+        curl = curl_easy_init();
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &result);
-		
+        
         res = curl_easy_perform(curl);
         
         // libcurl internal error handling
@@ -1051,7 +1051,7 @@ DoPOSTrequest(const string &UrlEndPoint, const string &params, string &result)
         httpHeaders = curl_slist_append(httpHeaders, ("X-BFX-PAYLOAD:" + payload).c_str());
         httpHeaders = curl_slist_append(httpHeaders, ("X-BFX-SIGNATURE:" + signature).c_str());
         
-		curl = curl_easy_init();
+        curl = curl_easy_init();
         curl_easy_setopt(curl, CURLOPT_VERBOSE, 0L); // debug option
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
         curl_easy_setopt(curl, CURLOPT_POST, 1);
@@ -1059,9 +1059,9 @@ DoPOSTrequest(const string &UrlEndPoint, const string &params, string &result)
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, httpHeaders);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &result);
-		
+        
         res = curl_easy_perform(curl);
-		
+        
         // libcurl internal error handling
         if (res != CURLE_OK)
         {

--- a/BitfinexAPI.cpp
+++ b/BitfinexAPI.cpp
@@ -1007,9 +1007,12 @@ DoGETrequest(const string &UrlEndPoint, const string &params, string &result)
     if(curl) {
         
         string url = APIurl + UrlEndPoint + params;
+		
+		curl = curl_easy_init();
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &result);
+		
         res = curl_easy_perform(curl);
         
         // libcurl internal error handling
@@ -1048,6 +1051,7 @@ DoPOSTrequest(const string &UrlEndPoint, const string &params, string &result)
         httpHeaders = curl_slist_append(httpHeaders, ("X-BFX-PAYLOAD:" + payload).c_str());
         httpHeaders = curl_slist_append(httpHeaders, ("X-BFX-SIGNATURE:" + signature).c_str());
         
+		curl = curl_easy_init();
         curl_easy_setopt(curl, CURLOPT_VERBOSE, 0L); // debug option
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
         curl_easy_setopt(curl, CURLOPT_POST, 1);
@@ -1055,8 +1059,9 @@ DoPOSTrequest(const string &UrlEndPoint, const string &params, string &result)
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, httpHeaders);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &result);
+		
         res = curl_easy_perform(curl);
-        curl_slist_free_all(httpHeaders);
+		
         // libcurl internal error handling
         if (res != CURLE_OK)
         {

--- a/example.cpp
+++ b/example.cpp
@@ -39,7 +39,13 @@ int main(int argc, char *argv[])
         getline(ifs, accessKey);
         getline(ifs, secretKey);
         
-        BitfinexAPI bfxAPI(accessKey, secretKey);
+        BitfinexAPI bfxAPIpubl(accessKey, secretKey); //Use this curl for requests of public endpoints
+		BitfinexAPI bfxAPIauth(accessKey, secretKey); //Use this curl for requests of authenticated endpoints
+
+		/////////////////////////////////////////////////////////////////////////
+		// This magic is needed to avoid crashes at a public endpoint after the authenticated.
+		/////////////////////////////////////////////////////////////////////////
+
         string response;
         int errCode;
         
@@ -51,29 +57,29 @@ int main(int argc, char *argv[])
 
         ///  Public endpoints ///
         
-        //  errCode = bfxAPI.getTicker(response, "btcusd");
-        //  errCode = bfxAPI.getStats(response, "btcusd");
-        //  errCode = bfxAPI.getFundingBook(response, "USD", 50, 50);
-        //  errCode = bfxAPI.getOrderBook(response, "btcusd", 50, 50, 1);
-        //  errCode = bfxAPI.getTrades(response, "btcusd", 0L, 50);
-        //  errCode = bfxAPI.getLends(response, "USD", 0L, 50);
-        //  errCode = bfxAPI.getSymbols(response);
-        //  errCode = bfxAPI.getSymbolDetails(response);
+        //  errCode = bfxAPIpubl.getTicker(response, "btcusd");
+        //  errCode = bfxAPIpubl.getStats(response, "btcusd");
+        //  errCode = bfxAPIpubl.getFundingBook(response, "USD", 50, 50);
+        //  errCode = bfxAPIpubl.getOrderBook(response, "btcusd", 50, 50, 1);
+        //  errCode = bfxAPIpubl.getTrades(response, "btcusd", 0L, 50);
+        //  errCode = bfxAPIpubl.getLends(response, "USD", 0L, 50);
+        //  errCode = bfxAPIpubl.getSymbols(response);
+        //  errCode = bfxAPIpubl.getSymbolDetails(response);
         
         /// Authenticated endpoints ///
         
         //  Account  //
-        //  errCode = bfxAPI.getAccountInfo(response);
-        //  errCode = bfxAPI.getSummary(response);
-        //  errCode = bfxAPI.deposit(response, "bitcoin", "deposit", 1);
-        //  errCode = bfxAPI.getKeyPermissions(response);
-        //  errCode = bfxAPI.getMarginInfos(response);
-        //  errCode = bfxAPI.getBalances(response);
-        //  errCode = bfxAPI.transfer(response, 0.1, "BTC", "trading", "deposit");
-        //  errCode = bfxAPI.withdraw(response); // configure withdraw.conf file before use
+        //  errCode = bfxAPIauth.getAccountInfo(response);
+        //  errCode = bfxAPIauth.getSummary(response);
+        //  errCode = bfxAPIauth.deposit(response, "bitcoin", "deposit", 1);
+        //  errCode = bfxAPIauth.getKeyPermissions(response);
+        //  errCode = bfxAPIauth.getMarginInfos(response);
+        //  errCode = bfxAPIauth.getBalances(response);
+        //  errCode = bfxAPIauth.transfer(response, 0.1, "BTC", "trading", "deposit");
+        //  errCode = bfxAPIauth.withdraw(response); // configure withdraw.conf file before use
         //
         //  Orders  //
-        //  errCode = bfxAPI.newOrder(response, "btcusd", 0.01, 983, "sell", "exchange limit", 0, 1,
+        //  errCode = bfxAPIauth.newOrder(response, "btcusd", 0.01, 983, "sell", "exchange limit", 0, 1,
         //                           0, 0, 0);
         //
         //  How to create vOrders object for newOrders() call
@@ -83,9 +89,9 @@ int main(int argc, char *argv[])
         //      {"btcusd", 0.1, 950, "sell", "exchange limit"},
         //      {"btcusd", 0.1, 950, "sell", "exchange limit"}
         //  };
-        //  errCode = bfxAPI.newOrders(response, orders);
+        //  errCode = bfxAPIauth.newOrders(response, orders);
         //
-        //  errCode = bfxAPI.cancelOrder(response, 13265453586LL);
+        //  errCode = bfxAPIauth.cancelOrder(response, 13265453586LL);
         //
         //  How to create ids object for cancelOrders() call
         //  BitfinexAPI::vIds ids =
@@ -94,33 +100,33 @@ int main(int argc, char *argv[])
         //      12356754322LL,
         //      12354996754LL
         //  };
-        //  errCode = bfxAPI.cancelOrders(response, ids);
+        //  errCode = bfxAPIauth.cancelOrders(response, ids);
         //
-        //  errCode = bfxAPI.cancelAllOrders(response);
-        //  errCode = bfxAPI.replaceOrder(response, 1321548521LL, "btcusd", 0.05, 1212, "sell",
+        //  errCode = bfxAPIauth.cancelAllOrders(response);
+        //  errCode = bfxAPIauth.replaceOrder(response, 1321548521LL, "btcusd", 0.05, 1212, "sell",
         //                                "exchange limit", 0, 0);
-        //  errCode = bfxAPI.getOrderStatus(response, 12113548453LL);
-        //  errCode = bfxAPI.getActiveOrders(response);
+        //  errCode = bfxAPIauth.getOrderStatus(response, 12113548453LL);
+        //  errCode = bfxAPIauth.getActiveOrders(response);
         //
         //  Positions  //
-        //  errCode = bfxAPI.getActivePositions(response);
-        //  errCode = bfxAPI.claimPosition(response, 156321412LL, 150);
+        //  errCode = bfxAPIauth.getActivePositions(response);
+        //  errCode = bfxAPIauth.claimPosition(response, 156321412LL, 150);
         //
         //  Historical data  //
-        //  errCode = bfxAPI.getBalanceHistory(response, "USD", 0L, 0L, 500, "all");
-        //  errCode = bfxAPI.getDWHistory(response, "BTC", "all", 0L , 0L, 500);
-        //  errCode = bfxAPI.getPastTrades(response, "btcusd", 0L, 0L, 500, 0);
+        //  errCode = bfxAPIauth.getBalanceHistory(response, "USD", 0L, 0L, 500, "all");
+        //  errCode = bfxAPIauth.getDWHistory(response, "BTC", "all", 0L , 0L, 500);
+        //  errCode = bfxAPIauth.getPastTrades(response, "btcusd", 0L, 0L, 500, 0);
         //
         //  Margin funding  //
-        //  errCode = bfxAPI.newOffer(response, "USD", 12000, 25.2, 30, "lend");
-        //  errCode = bfxAPI.cancelOffer(response, 12354245628LL);
-        //  errCode = bfxAPI.getOfferStatus(response, 12313541215LL);
-        //  errCode = bfxAPI.getActiveCredits(response);
-        //  errCode = bfxAPI.getOffers(response);
-        //  errCode = bfxAPI.getTakenFunds(response);
-        //  errCode = bfxAPI.getUnusedTakenFunds(response);
-        //  errCode = bfxAPI.getTotalTakenFunds(response);
-        //  errCode = bfxAPI.closeLoan(response, 1235845634LL);
+        //  errCode = bfxAPIauth.newOffer(response, "USD", 12000, 25.2, 30, "lend");
+        //  errCode = bfxAPIauth.cancelOffer(response, 12354245628LL);
+        //  errCode = bfxAPIauth.getOfferStatus(response, 12313541215LL);
+        //  errCode = bfxAPIauth.getActiveCredits(response);
+        //  errCode = bfxAPIauth.getOffers(response);
+        //  errCode = bfxAPIauth.getTakenFunds(response);
+        //  errCode = bfxAPIauth.getUnusedTakenFunds(response);
+        //  errCode = bfxAPIauth.getTotalTakenFunds(response);
+        //  errCode = bfxAPIauth.closeLoan(response, 1235845634LL);
         
         /////////////////////////////////////////////////////////////////////////
         /////////////////////////////////////////////////////////////////////////

--- a/example.cpp
+++ b/example.cpp
@@ -39,8 +39,7 @@ int main(int argc, char *argv[])
         getline(ifs, accessKey);
         getline(ifs, secretKey);
         
-        BitfinexAPI bfxAPIpubl(accessKey, secretKey); //Use this curl for requests of public endpoints
-		BitfinexAPI bfxAPIauth(accessKey, secretKey); //Use this curl for requests of authenticated endpoints
+        BitfinexAPI bfxAPI(accessKey, secretKey);
 
 		/////////////////////////////////////////////////////////////////////////
 		// This magic is needed to avoid crashes at a public endpoint after the authenticated.
@@ -57,29 +56,29 @@ int main(int argc, char *argv[])
 
         ///  Public endpoints ///
         
-        //  errCode = bfxAPIpubl.getTicker(response, "btcusd");
-        //  errCode = bfxAPIpubl.getStats(response, "btcusd");
-        //  errCode = bfxAPIpubl.getFundingBook(response, "USD", 50, 50);
-        //  errCode = bfxAPIpubl.getOrderBook(response, "btcusd", 50, 50, 1);
-        //  errCode = bfxAPIpubl.getTrades(response, "btcusd", 0L, 50);
-        //  errCode = bfxAPIpubl.getLends(response, "USD", 0L, 50);
-        //  errCode = bfxAPIpubl.getSymbols(response);
-        //  errCode = bfxAPIpubl.getSymbolDetails(response);
+        //  errCode = bfxAPI.getTicker(response, "btcusd");
+        //  errCode = bfxAPI.getStats(response, "btcusd");
+        //  errCode = bfxAPI.getFundingBook(response, "USD", 50, 50);
+        //  errCode = bfxAPI.getOrderBook(response, "btcusd", 50, 50, 1);
+        //  errCode = bfxAPI.getTrades(response, "btcusd", 0L, 50);
+        //  errCode = bfxAPI.getLends(response, "USD", 0L, 50);
+        //  errCode = bfxAPI.getSymbols(response);
+        //  errCode = bfxAPI.getSymbolDetails(response);
         
         /// Authenticated endpoints ///
         
         //  Account  //
-        //  errCode = bfxAPIauth.getAccountInfo(response);
-        //  errCode = bfxAPIauth.getSummary(response);
-        //  errCode = bfxAPIauth.deposit(response, "bitcoin", "deposit", 1);
-        //  errCode = bfxAPIauth.getKeyPermissions(response);
-        //  errCode = bfxAPIauth.getMarginInfos(response);
-        //  errCode = bfxAPIauth.getBalances(response);
-        //  errCode = bfxAPIauth.transfer(response, 0.1, "BTC", "trading", "deposit");
-        //  errCode = bfxAPIauth.withdraw(response); // configure withdraw.conf file before use
+        //  errCode = bfxAPI.getAccountInfo(response);
+        //  errCode = bfxAPI.getSummary(response);
+        //  errCode = bfxAPI.deposit(response, "bitcoin", "deposit", 1);
+        //  errCode = bfxAPI.getKeyPermissions(response);
+        //  errCode = bfxAPI.getMarginInfos(response);
+        //  errCode = bfxAPI.getBalances(response);
+        //  errCode = bfxAPI.transfer(response, 0.1, "BTC", "trading", "deposit");
+        //  errCode = bfxAPI.withdraw(response); // configure withdraw.conf file before use
         //
         //  Orders  //
-        //  errCode = bfxAPIauth.newOrder(response, "btcusd", 0.01, 983, "sell", "exchange limit", 0, 1,
+        //  errCode = bfxAPI.newOrder(response, "btcusd", 0.01, 983, "sell", "exchange limit", 0, 1,
         //                           0, 0, 0);
         //
         //  How to create vOrders object for newOrders() call
@@ -89,9 +88,9 @@ int main(int argc, char *argv[])
         //      {"btcusd", 0.1, 950, "sell", "exchange limit"},
         //      {"btcusd", 0.1, 950, "sell", "exchange limit"}
         //  };
-        //  errCode = bfxAPIauth.newOrders(response, orders);
+        //  errCode = bfxAPI.newOrders(response, orders);
         //
-        //  errCode = bfxAPIauth.cancelOrder(response, 13265453586LL);
+        //  errCode = bfxAPI.cancelOrder(response, 13265453586LL);
         //
         //  How to create ids object for cancelOrders() call
         //  BitfinexAPI::vIds ids =
@@ -100,33 +99,33 @@ int main(int argc, char *argv[])
         //      12356754322LL,
         //      12354996754LL
         //  };
-        //  errCode = bfxAPIauth.cancelOrders(response, ids);
+        //  errCode = bfxAPI.cancelOrders(response, ids);
         //
-        //  errCode = bfxAPIauth.cancelAllOrders(response);
-        //  errCode = bfxAPIauth.replaceOrder(response, 1321548521LL, "btcusd", 0.05, 1212, "sell",
+        //  errCode = bfxAPI.cancelAllOrders(response);
+        //  errCode = bfxAPI.replaceOrder(response, 1321548521LL, "btcusd", 0.05, 1212, "sell",
         //                                "exchange limit", 0, 0);
-        //  errCode = bfxAPIauth.getOrderStatus(response, 12113548453LL);
-        //  errCode = bfxAPIauth.getActiveOrders(response);
+        //  errCode = bfxAPI.getOrderStatus(response, 12113548453LL);
+        //  errCode = bfxAPI.getActiveOrders(response);
         //
         //  Positions  //
-        //  errCode = bfxAPIauth.getActivePositions(response);
-        //  errCode = bfxAPIauth.claimPosition(response, 156321412LL, 150);
+        //  errCode = bfxAPI.getActivePositions(response);
+        //  errCode = bfxAPI.claimPosition(response, 156321412LL, 150);
         //
         //  Historical data  //
-        //  errCode = bfxAPIauth.getBalanceHistory(response, "USD", 0L, 0L, 500, "all");
-        //  errCode = bfxAPIauth.getDWHistory(response, "BTC", "all", 0L , 0L, 500);
-        //  errCode = bfxAPIauth.getPastTrades(response, "btcusd", 0L, 0L, 500, 0);
+        //  errCode = bfxAPI.getBalanceHistory(response, "USD", 0L, 0L, 500, "all");
+        //  errCode = bfxAPI.getDWHistory(response, "BTC", "all", 0L , 0L, 500);
+        //  errCode = bfxAPI.getPastTrades(response, "btcusd", 0L, 0L, 500, 0);
         //
         //  Margin funding  //
-        //  errCode = bfxAPIauth.newOffer(response, "USD", 12000, 25.2, 30, "lend");
-        //  errCode = bfxAPIauth.cancelOffer(response, 12354245628LL);
-        //  errCode = bfxAPIauth.getOfferStatus(response, 12313541215LL);
-        //  errCode = bfxAPIauth.getActiveCredits(response);
-        //  errCode = bfxAPIauth.getOffers(response);
-        //  errCode = bfxAPIauth.getTakenFunds(response);
-        //  errCode = bfxAPIauth.getUnusedTakenFunds(response);
-        //  errCode = bfxAPIauth.getTotalTakenFunds(response);
-        //  errCode = bfxAPIauth.closeLoan(response, 1235845634LL);
+        //  errCode = bfxAPI.newOffer(response, "USD", 12000, 25.2, 30, "lend");
+        //  errCode = bfxAPI.cancelOffer(response, 12354245628LL);
+        //  errCode = bfxAPI.getOfferStatus(response, 12313541215LL);
+        //  errCode = bfxAPI.getActiveCredits(response);
+        //  errCode = bfxAPI.getOffers(response);
+        //  errCode = bfxAPI.getTakenFunds(response);
+        //  errCode = bfxAPI.getUnusedTakenFunds(response);
+        //  errCode = bfxAPI.getTotalTakenFunds(response);
+        //  errCode = bfxAPI.closeLoan(response, 1235845634LL);
         
         /////////////////////////////////////////////////////////////////////////
         /////////////////////////////////////////////////////////////////////////

--- a/example.cpp
+++ b/example.cpp
@@ -40,11 +40,6 @@ int main(int argc, char *argv[])
         getline(ifs, secretKey);
         
         BitfinexAPI bfxAPI(accessKey, secretKey);
-
-		/////////////////////////////////////////////////////////////////////////
-		// This magic is needed to avoid crashes at a public endpoint after the authenticated.
-		/////////////////////////////////////////////////////////////////////////
-
         string response;
         int errCode;
         


### PR DESCRIPTION
It crashes at request of a public endpoint after request of an authenticated endpoint.
Because of using the same curl during DoGETrequest and DoPOSTrequest, but the last injects trash (for DoGETrequest) into curl.